### PR TITLE
First pass of resty templates to override the behaviour of oapi-codegen

### DIFF
--- a/examples/petstore/client_test.go
+++ b/examples/petstore/client_test.go
@@ -1,13 +1,60 @@
 package petstore
 
 import (
+	"context"
+	"net/http"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestNewClient(t *testing.T) {
-	client, err := NewClient("a")
-	assert.Nil(t, err)
-	assert.NotNil(t, client)
+type DryRunTransport struct {
+	Handler func(*http.Request) (*http.Response, error)
+}
+
+func (dr *DryRunTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	return dr.Handler(r)
+}
+
+type PetStoreSuite struct {
+	suite.Suite
+	transport *DryRunTransport
+	client    ClientInterface
+}
+
+func (suite *PetStoreSuite) SetupTest() {
+	var err error
+	suite.transport = &DryRunTransport{}
+	suite.client, err = NewClient("http://invalid.localdomain/", WithRoundTripper(suite.transport))
+	suite.Require().Nil(err)
+}
+
+func TestPetStoreSuite(t *testing.T) {
+	suite.Run(t, new(PetStoreSuite))
+}
+
+func (suite *PetStoreSuite) TestAdd() {
+	suite.transport.Handler = func(r *http.Request) (*http.Response, error) {
+		return httpmock.NewJsonResponse(200, map[string]any{
+			"id":        123,
+			"name":      "Midnight",
+			"photoUrls": nil,
+			"status":    "sold",
+		})
+	}
+
+	resp, err := suite.client.Pet().Add(context.Background())
+	suite.Nil(err)
+	suite.NotNil(resp)
+	suite.EqualValues(*resp.Id, 123)
+	suite.Equal(resp.Name, "Midnight")
+}
+
+func (suite *PetStoreSuite) TestDelete() {
+	suite.transport.Handler = func(r *http.Request) (*http.Response, error) {
+		return httpmock.NewBytesResponse(200, []byte{}), nil
+	}
+	err := suite.client.Pet().Delete(context.Background(), 0, nil)
+	suite.Nil(err)
 }

--- a/examples/petstore/gen.config.yaml
+++ b/examples/petstore/gen.config.yaml
@@ -4,6 +4,7 @@
 # yamllint enable
 package: petstore
 output: client.gen.go
+input: https://raw.githubusercontent.com/swagger-api/swagger-petstore/refs/tags/swagger-petstore-v3-1.0.26/src/main/resources/openapi.yaml
 generate:
   models: true
   client: true

--- a/examples/petstore/gen.go
+++ b/examples/petstore/gen.go
@@ -1,4 +1,4 @@
 package petstore
 
-//go:generate go run ../../main.go --config gen.config.yaml https://raw.githubusercontent.com/swagger-api/swagger-petstore/refs/tags/swagger-petstore-v3-1.0.26/src/main/resources/openapi.yaml
+//go:generate go run ../../main.go --config gen.config.yaml
 //go:generate go mod tidy

--- a/go.mod
+++ b/go.mod
@@ -3,24 +3,26 @@ module github.com/ashb/oapi-resty-codegen
 go 1.23.7
 
 require (
+	github.com/getkin/kin-openapi v0.127.0
 	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/text v0.24.0
 	gopkg.in/yaml.v2 v2.4.0
+	resty.dev/v3 v3.0.0-beta.2
 )
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
-	github.com/getkin/kin-openapi v0.127.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/yaml v0.3.1 // indirect
+	github.com/jarcoal/httpmock v1.4.0
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
@@ -30,7 +32,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/sys v0.23.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/yaml v0.3.1 h1:f0+ZpmhfBSS4MhG+4HYseMdJhoeeopbSKbq5Rpeelso=
 github.com/invopop/yaml v0.3.1/go.mod h1:PMOp3nn4/12yEZUFfmOuNHJsZToEEOwoWsT+D81KkeA=
+github.com/jarcoal/httpmock v1.4.0 h1:BvhqnH0JAYbNudL2GMJKgOHe2CtKlzJ/5rWKyp+hc2k=
+github.com/jarcoal/httpmock v1.4.0/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
@@ -60,6 +62,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX48g9wI=
+github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -122,8 +126,8 @@ golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
-golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -143,8 +147,8 @@ golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.23.0 h1:YfKFowiIMvtgl1UERQoTPPToxltDeZfbj4H7dVUCwmM=
-golang.org/x/sys v0.23.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -187,3 +191,5 @@ gopkg.in/yaml.v3 v3.0.0-20191026110619-0b21df46bc1d/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+resty.dev/v3 v3.0.0-beta.2 h1:xu4mGAdbCLuc3kbk7eddWfWm4JfhwDtdapwss5nCjnQ=
+resty.dev/v3 v3.0.0-beta.2/go.mod h1:OgkqiPvTDtOuV4MGZuUDhwOpkY8enjOsjjMzeOHefy4=

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -1,25 +1,74 @@
 package generator
 
-import "github.com/oapi-codegen/oapi-codegen/v2/pkg/codegen"
+import (
+	"embed"
+	"fmt"
+	"path"
 
-func GenerateTypesGo() ([]byte, error) {
-	ccfg := codegen.Configuration{
-		PackageName: "a",
-		Compatibility: codegen.CompatibilityOptions{
-			AlwaysPrefixEnumValues: true,
-		},
-		Generate: codegen.GenerateOptions{
-			Models: true,
-		},
-		OutputOptions: codegen.OutputOptions{
-			SkipPrune: true,
-			UserTemplates: map[string]string{
-				"imports.tmpl": "A",
-			},
-		},
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oapi-codegen/oapi-codegen/v2/pkg/codegen"
+	"github.com/oapi-codegen/oapi-codegen/v2/pkg/util"
+)
+
+//go:embed templates/*
+var f embed.FS
+
+type GenerateArgs struct {
+	codegen.Configuration `yaml:",inline"`
+
+	// OutputFile is the filename to output.
+	OutputFile string `yaml:"output,omitempty"`
+	// Input filename is file (or URL) to read input from
+	Input string `yaml:"input,omitempty"`
+	// Spec is to provide a loaded spec already. Mutually exclusive with Input
+	Spec *openapi3.T
+}
+
+func Generate(opts GenerateArgs) (string, error) {
+	templates := map[string]string{}
+
+	if err := opts.Validate(); err != nil {
+		return "", fmt.Errorf("configuration error: %w", err)
 	}
 
-	codegen.Generate(nil, ccfg)
+	overlayOpts := util.LoadSwaggerWithOverlayOpts{
+		Path: opts.OutputOptions.Overlay.Path,
+		// default to strict, but can be overridden
+		Strict: true,
+	}
 
-	return nil, nil
+	if opts.OutputOptions.Overlay.Strict != nil {
+		overlayOpts.Strict = *opts.OutputOptions.Overlay.Strict
+	}
+	opts.AdditionalImports = append(opts.AdditionalImports, codegen.AdditionalImport{Package: "resty.dev/v3"})
+
+	if opts.Input != "" {
+		var err error
+		opts.Spec, err = util.LoadSwaggerWithOverlay(opts.Input, overlayOpts)
+		if err != nil {
+			return "", fmt.Errorf("error loading swagger spec in %q\n: %w", opts.Input, err)
+		}
+	}
+	if opts.Spec == nil {
+		return "", fmt.Errorf("one of spec or input filename must be provided")
+	}
+
+	dirName := "templates"
+	entries, err := f.ReadDir(dirName)
+	if err != nil {
+		return "", fmt.Errorf("unable to read templates: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		content, err := f.ReadFile(path.Join(dirName, entry.Name()))
+		if err != nil {
+			return "", fmt.Errorf("unable to read template: %w", err)
+		}
+		templates[entry.Name()] = string(content)
+	}
+	opts.OutputOptions.UserTemplates = templates
+
+	return codegen.Generate(opts.Spec, opts.Configuration)
 }

--- a/pkg/generator/templates/client-with-responses.tmpl
+++ b/pkg/generator/templates/client-with-responses.tmpl
@@ -1,0 +1,116 @@
+{{range $tag, $ops := . | operationsByTag -}}
+{{end}}{{/* operationsByTag -*/}}
+
+
+{{range $tag, $ops := . | operationsByTag -}}
+{{- $class := printf "%s%s" ($tag | tagToClass | lcFirst) "Client" -}}
+
+type {{ $class }} struct {
+  *resty.Client
+}
+{{- range $op := $ops }}{{
+$localOpid := $op | convertOperationWithTag $tag
+}}{{ with $op }}
+
+{{ $responseTypeName := "any" -}}
+{{ $responseTypeDefinitions := getResponseTypeDefinitions . -}}
+{{ $hasRespType := ge ($responseTypeDefinitions | len) 1 -}}
+{{ if $hasRespType -}}
+{{ $responseTypeName = (index $responseTypeDefinitions 0).Schema.GoType -}}
+{{ end -}}
+
+// {{ $localOpid }} returns the lower level [resty.Response]
+func (c *{{ $class }}) {{ $localOpid }}Response(ctx context.Context
+    {{- .PathParams | genParamArgs -}}
+    {{if .RequiresParamObject}}, params *{{.OperationId}}Params{{ end -}}
+) (resp *resty.Response, err error) {
+    var errResp map[string]any
+    {{ if $hasRespType -}}
+    var res {{ $responseTypeName }}
+    {{- end }}
+
+{{range $paramIdx, $param := .PathParams -}}
+    var pathParam{{$paramIdx}} string
+    {{if .IsPassThrough}}
+    pathParam{{$paramIdx}} = {{.GoVariableName}}
+    {{end}}
+    {{if .IsJson}}
+    var pathParamBuf{{$paramIdx}} []byte
+    pathParamBuf{{$paramIdx}}, err = json.Marshal({{.GoVariableName}})
+    if err != nil {
+        return nil, err
+    }
+    pathParam{{$paramIdx}} = string(pathParamBuf{{$paramIdx}})
+    {{end}}
+    {{if .IsStyled}}
+    pathParam{{$paramIdx}}, err = runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocationPath, {{.GoVariableName}})
+    if err != nil {
+        return nil, err
+    }
+    {{end -}}
+{{ end -}}{{/* range .PathParams */}}
+    return c.R().
+    {{- range $paramIdx, $param := .PathParams}}
+      SetPathParam("{{ $param.ParamName }}", pathParam{{$paramIdx}}).{{end}}
+    {{if .RequiresParamObject }}SetBody(params).{{ end}}
+      SetError(errResp).
+    {{- if $hasRespType }}
+      SetResult(&res).
+    {{- end }}
+      {{ $op.Method | lower | title }}("{{ .Path }}")
+}
+
+func (c *{{ $class }}) {{ $localOpid }}(ctx context.Context
+    {{- genParamArgs .PathParams -}}
+    {{if .RequiresParamObject}}, params *{{.OperationId}}Params{{ end -}}
+  {{- if $hasRespType -}}
+  ) (*{{ $responseTypeName }}, error) {
+    res, err := c.{{ $localOpid }}Response(ctx{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{ end -}})
+    if err != nil {
+      return nil, err
+    }
+
+    return res.Result().(*{{ $responseTypeName }}), nil
+{{- else -}}
+  ) error {
+    _, err := c.{{ $localOpid }}Response(ctx{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{ end -}})
+    return err
+{{- end }}
+}
+
+{{end }}{{/* with $op -*/}}
+{{end }}{{/* operations -*/}}
+{{end}}{{/* operationsByTag -*/}}
+
+{{range $tag, $ops := . | operationsByTag -}}
+
+{{- $iface := printf "%sClient" ($tag | tagToClass) -}}
+{{- $class := ($iface | lcFirst) -}}
+type {{ $iface }} interface {
+{{- range $op := $ops }}
+{{ $responseTypeName := "any" -}}
+{{ $responseTypeDefinitions := getResponseTypeDefinitions . -}}
+{{ $hasRespType := ge ($responseTypeDefinitions | len) 1 -}}
+{{ if $hasRespType -}}
+{{ $responseTypeName = (index $responseTypeDefinitions 0).Schema.GoType -}}
+{{ end -}}
+  {{ toGoComment $op.Spec.Description "" }}
+  {{ $op | convertOperationWithTag $tag }}(ctx context.Context
+    {{- $op.PathParams | genParamArgs -}}
+    {{if $op.RequiresParamObject}}, params *{{$op.OperationId}}Params{{ end -}}
+  {{- if $hasRespType -}}
+  ) (*{{ $responseTypeName }}, error)
+{{- else -}}
+  ) error
+{{- end }}
+
+  // Returns the [resty.Response] for {{ $op | convertOperationWithTag $tag }}
+  {{ $op | convertOperationWithTag $tag }}Response(ctx context.Context
+    {{- $op.PathParams | genParamArgs -}}
+    {{if $op.RequiresParamObject}}, params *{{$op.OperationId}}Params{{ end -}}
+  ) (*resty.Response, error)
+
+{{- end}}
+}
+var _ {{ $iface }} = (*{{ $class }})(nil)
+{{end}}{{/* operationsByTag -*/}}

--- a/pkg/generator/templates/client.tmpl
+++ b/pkg/generator/templates/client.tmpl
@@ -1,0 +1,83 @@
+// RequestEditorFn	is the function signature for the RequestEditor callback function
+{{$clientTypeName := opts.OutputOptions.ClientTypeName -}}
+
+// {{ $clientTypeName }} which conforms to the OpenAPI3 specification for this service.
+type {{ $clientTypeName }} struct {
+	// The endpoint of the server conforming to this interface, with scheme,
+	// https://api.deepmap.com for example. This can contain a path relative
+	// to the server, such as https://api.deepmap.com/dev-test, and all the
+	// paths in the swagger spec will be appended to the server.
+	Server string
+
+	*resty.Client
+}
+// ClientOption allows setting custom parameters during construction
+type ClientOption func(*{{ $clientTypeName }}) error
+
+func New{{ $clientTypeName }}(server string, opts ...ClientOption) ({{ $clientTypeName }}Interface, error) {
+	// create a client with sane default values
+	client := {{ $clientTypeName }}{
+			Server: server,
+			Client: resty.New(),
+	}
+	// mutate client and add all optional params
+	for _, o := range opts {
+		if err := o(&client); err != nil {
+			return nil, err
+		}
+	}
+	// ensure the server URL always has a trailing slash
+	if !strings.HasSuffix(client.Server, "/") {
+		client.Server += "/"
+	}
+
+	// create resty Client, if not already present
+	if client.Client == nil {
+		client.Client = resty.New()
+		client.Client.SetBaseURL(client.Server)
+	}
+	return &client, nil
+}
+
+// WithHTTPClient allows overriding the default Doer, which is
+// automatically created using http.Client. This is useful for tests.
+//
+// This will re-create the resty Client, so this should appear before any
+// middleware is added
+func WithHTTPClient(hc *http.Client) ClientOption {
+	return func(c *{{ $clientTypeName }}) error {
+		c.Client = resty.NewWithClient(hc)
+		return nil
+	}
+}
+
+// WithRoundTripper method sets custom http.Transport or any http.RoundTripper
+// compatible interface implementation in the Resty client
+func WithRoundTripper(transport http.RoundTripper) ClientOption {
+	return func(c *{{ $clientTypeName }}) error {
+		c.Client.SetTransport(transport)
+		return nil
+	}
+}
+
+// WithRequestEditorFn allows setting up a callback function, which will be
+// called right before sending the request. This can be used to mutate the request.
+func WithRequestMiddleware(mw resty.RequestMiddleware) ClientOption {
+	return func(c *{{ $clientTypeName }}) error {
+		c.Client = c.Client.AddRequestMiddleware(mw)
+		return nil
+	}
+}
+
+{{range $tag, $ops := . | operationsByTag -}}
+func (c *{{ $clientTypeName }}){{ $tag | tagToClass }}() {{ $tag | tagToClass }}Client {
+	return &{{ printf "%s%s" ($tag | tagToClass | lcFirst) "Client"}}{c.Client}
+}
+{{end}}{{/* operationsByTag -*/}}
+
+type {{ $clientTypeName }}Interface interface {
+{{range $tag, $ops := . | operationsByTag -}}
+	// {{ $tag | tagToClass }} deals with all the {{ $tag }} endpoints
+	{{ $tag | tagToClass }}() {{ $tag | tagToClass }}Client
+{{end}}{{/* operationsByTag -*/}}
+}


### PR DESCRIPTION
I'm sure there will be more edge cases I haven't discovered yet, but this
works for the few simple test cases in the Petstore spec, and it compiles
which is a start!

Future work still to do is test that the following work
- request bodies
- query params
- union response types