### PR TITLE
resty templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# oapi-resty-codegen
+
+An OpenAPI client generator that provides "literate" programming, and
+
+The main goals are:
+
+- Namespace/group operations rather than have them all be in a single flat
+  namespace.
+
+  I use the first tag for operations as the name fo the group to put it in
+
+- Automatic HTTP error code handling. net/http doesn't treat a 4xx or 5xx
+  response as an error, which makes some sense for raw HTTP client, but as a
+  REST API client, an http error should be reported as an error to the Go
+  Code.
+
+## Example
+
+The "canonical example" [Pet Store][petstore] creates the following interfaces:
+
+```go
+type ClientInterface interface {
+	// Pet deals with all the pet endpoints
+	Pet() PetClient
+	// Store deals with all the store endpoints
+	Store() StoreClient
+	// User deals with all the user endpoints
+	User() UserClient
+}
+
+type PetClient interface {
+	// Add a new pet to the store.
+	Add(ctx context.Context, body *Pet) (*Pet, error)
+	// AddResponse is a lower level version of [Add] and provides access to the raw [resty.Response]
+	AddResponse(ctx context.Context, body *Pet) (*resty.Response, error)
+
+	// Update an existing pet by Id.
+	Update(ctx context.Context, body *Pet) (*Pet, error)
+	// UpdateResponse is a lower level version of [Update] and provides access to the raw [resty.Response]
+	UpdateResponse(ctx context.Context, body *Pet) (*resty.Response, error)
+
+	// Multiple status values can be provided with comma separated strings.
+	FindByStatus(ctx context.Context, params *FindPetsByStatusParams) (*[]Pet, error)
+	// FindByStatusResponse is a lower level version of [FindByStatus] and provides access to the raw [resty.Response]
+	FindByStatusResponse(ctx context.Context, params *FindPetsByStatusParams) (*resty.Response, error)
+
+	// Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+	FindByTags(ctx context.Context, params *FindPetsByTagsParams) (*[]Pet, error)
+	// FindByTagsResponse is a lower level version of [FindByTags] and provides access to the raw [resty.Response]
+	FindByTagsResponse(ctx context.Context, params *FindPetsByTagsParams) (*resty.Response, error)
+
+	// Delete a pet.
+	Delete(ctx context.Context, petId int64, params *DeletePetParams) error
+	// DeleteResponse is a lower level version of [Delete] and provides access to the raw [resty.Response]
+	DeleteResponse(ctx context.Context, petId int64, params *DeletePetParams) (*resty.Response, error)
+
+	// Returns a single pet.
+	GetById(ctx context.Context, petId int64) (*Pet, error)
+	// GetByIdResponse is a lower level version of [GetById] and provides access to the raw [resty.Response]
+	GetByIdResponse(ctx context.Context, petId int64) (*resty.Response, error)
+
+    // ...
+```
+
+And an example of how this is used in a client:
+
+```go
+	var id int64 = 123
+	status := PetStatus("sold")
+	resp, err := suite.client.Pet().Add(context.Background(), &Pet{
+		Category: &Category{},
+		Id:       &id,
+		Name:     "Midnight",
+		Status:   &status,
+	})
+```
+
+`err` will be non-nil if there is a network issue _or_ if the HTTP status code is `> 399`. You can see more examples of this in [`examples/petstore/client_test.go`](examples/petstore/client_test.go)
+
+[petstore]: https://raw.githubusercontent.com/swagger-api/swagger-petstore/refs/tags/swagger-petstore-v3-1.0.26/src/main/resources/openapi.yaml

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
+	github.com/gertd/go-pluralize v0.2.1
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/uuid v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936/go.mod h1:ttYvX5ql
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/gertd/go-pluralize v0.2.1 h1:M3uASbVjMnTsPb0PNqg+E/24Vwigyo/tvyMTtAlLgiA=
+github.com/gertd/go-pluralize v0.2.1/go.mod h1:rbYaKDbsXxmRfr8uygAEKhOWsjyrrqrkHVpZvoOp8zk=
 github.com/getkin/kin-openapi v0.127.0 h1:Mghqi3Dhryf3F8vR370nN67pAERW+3a95vomb3MAREY=
 github.com/getkin/kin-openapi v0.127.0/go.mod h1:OZrfXzUfGrNbsKj+xmFBx6E5c6yH3At/tAKSc2UszXM=
 github.com/go-openapi/jsonpointer v0.21.0 h1:YgdVicSA9vH5RiHs9TZW5oyafXZFc6+2Vc1rr/O9oNQ=

--- a/pkg/generator/template_helpers_test.go
+++ b/pkg/generator/template_helpers_test.go
@@ -1,0 +1,31 @@
+package generator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/oapi-codegen/oapi-codegen/v2/pkg/codegen"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertOperationWithTag(t *testing.T) {
+	cases := []struct {
+		tag      string
+		opid     string
+		expected string
+	}{
+		{"Asset Events", "GetAssetEventByAssetNameUri", "GetByAssetNameUri"},
+		{"Variables", "GetVariable", "Get"},
+		{"Pet", "FindPetsByStatus", "FindByStatus"},
+		{"Pet", "FindPetsByStatus", "FindByStatus"},
+		{"Abilities", "GetAbility", "Get"},
+		{"Abilities", "AbilityGet", "Get"},
+	}
+
+	for _, test := range cases {
+		t.Run(fmt.Sprintf("(%s,%s)", test.tag, test.opid), func(t *testing.T) {
+			op := codegen.OperationDefinition{OperationId: test.opid}
+			assert.Equal(t, convertOperationWithTag(test.tag, op), test.expected)
+		})
+	}
+}

--- a/pkg/generator/templates/client-with-responses.tmpl
+++ b/pkg/generator/templates/client-with-responses.tmpl
@@ -1,3 +1,57 @@
+{{define "fnParams" }}ctx context.Context
+    {{- .PathParams | genParamArgs -}}
+    {{if .RequiresParamObject}}, params *{{.OperationId}}Params{{ end -}}
+    {{if .BodyRequired}}, body *{{ (.Bodies | bestBody).Schema.GoType }}{{ end -}}
+    {{- end -}}{{/*- end block params -*/}}
+
+
+type GeneralHTTPError struct {
+  Response *resty.Response
+  JSON map[string]any
+  Text string
+}
+
+var errorTypes = map[int]string{
+            1: "informational response",
+            3: "redirect response",
+            4: "client error",
+            5: "server error",
+        }
+
+func (e GeneralHTTPError) Error() string {
+	var b strings.Builder
+	kind, ok := errorTypes[e.Response.StatusCode() / 100]
+	if !ok { kind = "unknown HTTP error"}
+	fmt.Fprintf(&b, "%s '%s'", kind, e.Response.Status())
+	if e.JSON != nil {
+		fmt.Fprintf(&b, " %v", e.JSON)
+	} else {
+		fmt.Fprintf(&b, " content=%q", e.Text)
+	}
+	return b.String()
+}
+
+func HandleError(client *resty.Client, resp *resty.Response) error {
+	if !resp.IsError() {
+		return nil
+	}
+
+	e := GeneralHTTPError{Response: resp}
+
+	// fmt.Printf("HandleError: IsRead: %v Error: %T\n", resp.IsRead, resp.Error())
+	e.Text = resp.String()
+	if resp.Header().Get("content-type") == "application/json" {
+		if json.Unmarshal([]byte(e.Text), &e.JSON) == nil {
+			e.Text = ""
+		}
+	}
+
+	// Set the parsed error back into the object so `resp.Error()` returns the populated one!
+	resp.Request.SetError(&e)
+
+	return &e
+}
+
 {{range $tag, $ops := . | operationsByTag -}}
 {{end}}{{/* operationsByTag -*/}}
 
@@ -8,9 +62,9 @@
 type {{ $class }} struct {
   *resty.Client
 }
-{{- range $op := $ops }}{{
-$localOpid := $op | convertOperationWithTag $tag
-}}{{ with $op }}
+{{- range $op := $ops }}
+{{- $localOpid := $op | convertOperationWithTag $tag }}
+{{- with $op }}
 
 {{ $responseTypeName := "any" -}}
 {{ $responseTypeDefinitions := getResponseTypeDefinitions . -}}
@@ -19,12 +73,8 @@ $localOpid := $op | convertOperationWithTag $tag
 {{ $responseTypeName = (index $responseTypeDefinitions 0).Schema.GoType -}}
 {{ end -}}
 
-// {{ $localOpid }} returns the lower level [resty.Response]
-func (c *{{ $class }}) {{ $localOpid }}Response(ctx context.Context
-    {{- .PathParams | genParamArgs -}}
-    {{if .RequiresParamObject}}, params *{{.OperationId}}Params{{ end -}}
-) (resp *resty.Response, err error) {
-    var errResp map[string]any
+// {{ $localOpid }}Response performs the HTTP request and returns the lower level [resty.Response]
+func (c *{{ $class }}) {{ $localOpid }}Response({{ template "fnParams" . }}) (resp *resty.Response, err error) {
     {{ if $hasRespType -}}
     var res {{ $responseTypeName }}
     {{- end }}
@@ -49,23 +99,59 @@ func (c *{{ $class }}) {{ $localOpid }}Response(ctx context.Context
     }
     {{end -}}
 {{ end -}}{{/* range .PathParams */}}
-    return c.R().
+{{range $paramIdx, $param := .Params -}}
+    var param{{$paramIdx}} string
+    {{if .IsPassThrough}}
+    path{{$paramIdx}} = {{.GoVariableName}}
+    {{end}}
+    {{if .IsJson}}
+    var paramBuf{{$paramIdx}} []byte
+    paramBuf{{$paramIdx}}, err = json.Marshal({{.GoVariableName}})
+    if err != nil {
+        return nil, err
+    }
+    param{{$paramIdx}} = string(paramBuf{{$paramIdx}})
+    {{end}}
+    {{if .IsStyled}}
+    param{{$paramIdx}}, err = runtime.StyleParamWithLocation("{{.Style}}", {{.Explode}}, "{{.ParamName}}", runtime.ParamLocation{{ .In | ucFirst }}, params.{{.GoName}})
+    if err != nil {
+        return nil, err
+    }
+    {{end -}}
+{{ end -}}{{/* range .Params */}}
+
+    {{ if .BodyRequired -}}
+    if body == nil {
+      return nil, fmt.Errorf("{{ $localOpid }} requires a non-nil body argument")
+    }
+    {{ end -}}
+    resp, err = c.R().
     {{- range $paramIdx, $param := .PathParams}}
       SetPathParam("{{ $param.ParamName }}", pathParam{{$paramIdx}}).{{end}}
-    {{if .RequiresParamObject }}SetBody(params).{{ end}}
-      SetError(errResp).
+    {{ range $paramIdx, $param := .Params -}}
+    {{ if eq $param.In "header" -}}
+    SetHeader({{printf "%q" $param.ParamName}}, param{{$paramIdx}}).
+    {{ else if eq $param.In "query" -}}
+    SetQueryParam({{printf "%q" $param.ParamName}}, param{{$paramIdx}}).
+    {{ end -}}
+    {{- end -}}{{/* range .Params */}}
+    {{if .BodyRequired }}SetBody(body).{{ end}}
     {{- if $hasRespType }}
       SetResult(&res).
     {{- end }}
       {{ $op.Method | lower | title }}("{{ .Path }}")
+    if err != nil {
+        return resp, err
+    }
+    return resp, HandleError(c.Client, resp)
 }
 
-func (c *{{ $class }}) {{ $localOpid }}(ctx context.Context
-    {{- genParamArgs .PathParams -}}
-    {{if .RequiresParamObject}}, params *{{.OperationId}}Params{{ end -}}
+func (c *{{ $class }}) {{ $localOpid }}({{ template "fnParams" . -}}
   {{- if $hasRespType -}}
   ) (*{{ $responseTypeName }}, error) {
-    res, err := c.{{ $localOpid }}Response(ctx{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{ end -}})
+    res, err := c.{{ $localOpid }}Response(ctx{{genParamNames .PathParams}}
+      {{- if .RequiresParamObject}}, params{{ end -}}
+      {{- if .BodyRequired }}, body{{ end }})
     if err != nil {
       return nil, err
     }
@@ -88,6 +174,7 @@ func (c *{{ $class }}) {{ $localOpid }}(ctx context.Context
 {{- $class := ($iface | lcFirst) -}}
 type {{ $iface }} interface {
 {{- range $op := $ops }}
+{{- $localOpid := $op | convertOperationWithTag $tag }}
 {{ $responseTypeName := "any" -}}
 {{ $responseTypeDefinitions := getResponseTypeDefinitions . -}}
 {{ $hasRespType := ge ($responseTypeDefinitions | len) 1 -}}
@@ -95,22 +182,20 @@ type {{ $iface }} interface {
 {{ $responseTypeName = (index $responseTypeDefinitions 0).Schema.GoType -}}
 {{ end -}}
   {{ toGoComment $op.Spec.Description "" }}
-  {{ $op | convertOperationWithTag $tag }}(ctx context.Context
-    {{- $op.PathParams | genParamArgs -}}
-    {{if $op.RequiresParamObject}}, params *{{$op.OperationId}}Params{{ end -}}
+  {{ $localOpid }}({{block "params" $op }}ctx context.Context
+    {{- .PathParams | genParamArgs -}}
+    {{if .RequiresParamObject}}, params *{{.OperationId}}Params{{ end -}}
+    {{if .BodyRequired}}, body *{{ (.Bodies | bestBody).Schema.GoType }}{{ end -}}
+    {{- end -}}{{/*- end block params -*/}}
   {{- if $hasRespType -}}
   ) (*{{ $responseTypeName }}, error)
 {{- else -}}
   ) error
 {{- end }}
+  // {{ $localOpid }}Response is a lower level version of [{{ $localOpid }}] and provides access to the raw [resty.Response]
+  {{ $localOpid }}Response({{ template "params" $op }}) (*resty.Response, error)
 
-  // Returns the [resty.Response] for {{ $op | convertOperationWithTag $tag }}
-  {{ $op | convertOperationWithTag $tag }}Response(ctx context.Context
-    {{- $op.PathParams | genParamArgs -}}
-    {{if $op.RequiresParamObject}}, params *{{$op.OperationId}}Params{{ end -}}
-  ) (*resty.Response, error)
-
-{{- end}}
+{{ end -}}
 }
 var _ {{ $iface }} = (*{{ $class }})(nil)
 {{end}}{{/* operationsByTag -*/}}


### PR DESCRIPTION
This makes use of the "user-templates" feature of oapi-codegen to create the
client I want.

The main goals are:

   - Namespace/group operations rather than have them all be in a single flat
     namespace.

     I use the first tag for operations as the name fo the group to put it in

   - Automatic HTTP error code handling. net/http doesn't treat a 4xx or 5xx
     response as an error, which makes some sense for raw HTTP client, but as a
     REST API client, an http error should be reported as an error to the Go
     Code.

I have chosen not to commit the generated code to the repo (as I am perhaps
unreasonably against doing that if I can avoid it.)