### PR TITLE
Downgrade some OpenAPI 3.1 specs to 3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.23.7
 
 require (
 	github.com/getkin/kin-openapi v0.127.0
+	github.com/google/go-cmp v0.6.0
 	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1
 	github.com/oapi-codegen/runtime v1.1.1
+	github.com/pb33f/libopenapi v0.21.10
 	github.com/spf13/cobra v1.7.0
-	github.com/stretchr/testify v1.9.0
+	github.com/stretchr/testify v1.10.0
 	golang.org/x/text v0.24.0
 	gopkg.in/yaml.v2 v2.4.0
 	resty.dev/v3 v3.0.0-beta.2
@@ -15,7 +17,11 @@ require (
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/google/uuid v1.5.0 // indirect
+	github.com/speakeasy-api/jsonpath v0.6.1 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.9-0.20240815153524-6ea36470d1bd // indirect
 )
 
 require (
@@ -38,5 +44,5 @@ require (
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -88,6 +92,8 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
 github.com/onsi/gomega v1.27.6/go.mod h1:PIQNjfQwkP3aQAH7lf7j87O/5FiNr+ZR8+ipb+qQlhg=
+github.com/pb33f/libopenapi v0.21.10 h1:CSy2asSXbDYBGRw9O+VgIrkE+ZyTW408HDoieORw3jk=
+github.com/pb33f/libopenapi v0.21.10/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -97,6 +103,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/speakeasy-api/jsonpath v0.6.1 h1:FWbuCEPGaJTVB60NZg2orcYHGZlelbNJAcIk/JGnZvo=
+github.com/speakeasy-api/jsonpath v0.6.1/go.mod h1:ymb2iSkyOycmzKwbEAYPJV/yi2rSmvBCLZJcyD+VVWw=
 github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54VRhy1aSutx0PQg=
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
@@ -108,12 +116,14 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
-github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
+github.com/wk8/go-ordered-map/v2 v2.1.9-0.20240815153524-6ea36470d1bd h1:dLuIF2kX9c+KknGJUdJi1Il1SDiTSK158/BB9kdgAew=
+github.com/wk8/go-ordered-map/v2 v2.1.9-0.20240815153524-6ea36470d1bd/go.mod h1:DbzwytT4g/odXquuOCqroKvtxxldI4nb3nuesHF/Exo=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/ashb/oapi-resty-codegen/pkg/openapi31downgrade"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/oapi-codegen/oapi-codegen/v2/pkg/codegen"
 	"github.com/oapi-codegen/oapi-codegen/v2/pkg/util"
@@ -51,6 +52,14 @@ func Generate(opts GenerateArgs) (string, error) {
 	}
 	if opts.Spec == nil {
 		return "", fmt.Errorf("one of spec or input filename must be provided")
+	}
+
+	if opts.Spec.OpenAPI == "3.1.0" {
+		var err error
+		opts.Spec, err = openapi31downgrade.DowngradeTo3_0(opts.Spec)
+		if err != nil {
+			return "", fmt.Errorf("error downgrading spec in %q to OpenAPI 3.0.0\n: %w", opts.Input, err)
+		}
 	}
 
 	dirName := "templates"

--- a/pkg/openapi31downgrade/downgrade.go
+++ b/pkg/openapi31downgrade/downgrade.go
@@ -1,0 +1,216 @@
+package openapi31downgrade
+
+import (
+	"iter"
+	"reflect"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel/high/base"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+)
+
+// DowngradeTo3_0 will attempt to downgrade the 3.1.x spec to v 3.0.3
+//
+// Only certain "transforms" are supported, and if the spec uses features that are not parsable/reresentable
+// by [openapi3.T] then the code flow won't even reach this far.
+func DowngradeTo3_0(spec *openapi3.T) (*openapi3.T, error) {
+	if strings.HasPrefix(spec.OpenAPI, "3.0.") {
+		return spec, nil
+	}
+	b, err := spec.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	doc, err := libopenapi.NewDocument(b)
+	if err != nil {
+		return nil, err
+	}
+
+	err = EditOpenAPISpec(doc)
+	if err != nil {
+		return nil, err
+	}
+
+	// render the document back to bytes and reload the model.
+	blob, _, _, errors := doc.RenderAndReload()
+
+	// if anything went wrong when re-rendering the v3 model, a slice of errors will be returned
+	if len(errors) > 0 {
+		err := (openapi3.MultiError)(errors)
+		return nil, err
+	}
+
+	loader := openapi3.NewLoader()
+	return loader.LoadFromData(blob)
+}
+
+// This _far_ from a complete conversion, it is just enough to get things working for the schema's I've
+// used.
+//
+// More examples welcome!
+
+func visitPaths(paths iter.Seq2[string, *v3.PathItem]) error {
+	for path, item := range paths {
+		for method, spec := range item.GetOperations().FromOldest() {
+			loc := []any{path, method}
+			for idx, param := range spec.Parameters {
+				err := visitParam(param, append(loc, "parameters", idx))
+				if err != nil {
+					return err
+				}
+			}
+			if spec.Responses.Default != nil {
+				err := visitResponse(spec.Responses.Default, append(loc, "responses", "default"))
+				if err != nil {
+					return err
+				}
+			}
+			for code, resp := range spec.Responses.Codes.FromNewest() {
+				err := visitResponse(resp, append(loc, "responses", code))
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func visitResponse(response *v3.Response, loc []any) error {
+	for ct, media := range response.Content.FromOldest() {
+		err := visitSchemaProxy(&media.Schema, append(loc, ct, "schema"))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func visitComponents(components *v3.Components) error {
+	for name, resp := range components.Responses.FromOldest() {
+		err := visitResponse(resp, []any{"components", "responses", name})
+		if err != nil {
+			return err
+		}
+	}
+
+	for name, proxy := range components.Schemas.FromOldest() {
+		if proxy.IsReference() {
+			continue
+		}
+		if schema := proxy.Schema(); schema != nil {
+			newSchema, err := visitSchema(schema, []any{"components", "schemas", name})
+			if err != nil {
+				return err
+			}
+			if newSchema != nil {
+				components.Schemas.Set(name, base.CreateSchemaProxy(newSchema))
+			}
+		}
+	}
+
+	return nil
+}
+
+func visitParam(param *v3.Parameter, loc []any) error {
+	return visitSchemaProxy(&param.Schema, append(loc, "schema"))
+}
+
+func visitSchemaProxy(schemaProxy **base.SchemaProxy, loc []any) error {
+	if (*schemaProxy).IsReference() {
+		return nil
+	}
+	if schema := (*schemaProxy).Schema(); schema != nil {
+		schema, err := visitSchema(schema, loc)
+		if err != nil {
+			return err
+		}
+		if schema != nil {
+			(*schemaProxy) = base.CreateSchemaProxy(schema)
+		}
+	}
+	return nil
+}
+
+func visitSchema(schema *base.Schema, loc []any) (*base.Schema, error) {
+	changed := false
+	if numOneOfs := len(schema.OneOf); numOneOfs > 0 {
+		lastType := schema.OneOf[numOneOfs-1].Schema().Type
+		if len(lastType) == 1 && lastType[0] == "null" {
+			schema.OneOf = schema.OneOf[0 : numOneOfs-1]
+			nullable := true
+			numOneOfs--
+			schema.Nullable = &nullable
+
+			// If it was only a single type left, collapse it.
+			if numOneOfs == 1 {
+				oneOf := schema.OneOf[0].Schema()
+				schema.OneOf = nil
+				copyNonZeroProps(schema, oneOf)
+			}
+			changed = true
+		}
+	} else if len(schema.Type) == 1 && schema.Type[0] == "null" {
+		schema.Type = nil
+		nullable := true
+		schema.Nullable = &nullable
+		changed = true
+	}
+
+	for name, propProxy := range schema.Properties.FromOldest() {
+		if propProxy.IsReference() {
+			continue
+		}
+		lloc := append(loc, "properties", name)
+		if prop := propProxy.Schema(); schema != nil {
+			newSchema, err := visitSchema(prop, lloc)
+			if err != nil {
+				return nil, err
+			}
+			if newSchema != nil {
+				schema.Properties.Set(name, base.CreateSchemaProxy(newSchema))
+				changed = true
+			}
+		}
+	}
+
+	if changed {
+		return schema, nil
+	}
+	return nil, nil
+}
+
+func copyNonZeroProps[T any](dest, src *T) {
+	source := reflect.ValueOf(src)
+	target := reflect.ValueOf(dest)
+	for i := range source.Elem().NumField() {
+		fld := source.Elem().Type().Field(i)
+		if !fld.IsExported() {
+			continue
+		}
+		val := source.Elem().Field(i)
+		if !val.IsZero() {
+			target.Elem().Field(i).Set(val)
+		}
+	}
+}
+
+func EditOpenAPISpec(doc libopenapi.Document) error {
+	// because we know this is a v3 spec, we can build a ready to go model from it.
+	v3Model, errors := doc.BuildV3Model()
+
+	// if anything went wrong when building the v3 model, a slice of errors will be returned
+	if len(errors) > 0 {
+		return (openapi3.MultiError)(errors)
+	}
+
+	visitPaths(v3Model.Model.Paths.PathItems.FromOldest())
+	visitComponents(v3Model.Model.Components)
+	v3Model.Model.Version = "3.0.3"
+
+	return nil
+}

--- a/pkg/openapi31downgrade/downgrade_test.go
+++ b/pkg/openapi31downgrade/downgrade_test.go
@@ -1,0 +1,70 @@
+package openapi31downgrade
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/suite"
+	"gopkg.in/yaml.v3"
+)
+
+type Suite struct {
+	suite.Suite
+}
+
+func TestSuite(t *testing.T) {
+	suite.Run(t, new(Suite))
+}
+
+func (s *Suite) TestDowngrade() {
+	// Find the paths of all input files in the data directory.
+	const suffix = "_in.yaml"
+	paths, err := filepath.Glob(filepath.Join("testdata", "*"+suffix))
+	if err != nil {
+		s.T().Fatal(err)
+	}
+	specToMap := func(spec *openapi3.T) map[string]any {
+		s.T().Helper()
+		var out map[string]any
+		bytes, err := yaml.Marshal(spec)
+		s.Require().NoError(err)
+		s.Require().NoError(yaml.Unmarshal(bytes, &out))
+		return out
+	}
+	for _, path := range paths {
+		path := path
+		base := filepath.Base(path)
+		testname := base[:len(base)-len(suffix)]
+		s.Run(testname, func() {
+			var convertedYAML, expectedYAML map[string]any
+
+			sourceBytes, err := os.ReadFile(path)
+			s.Require().NoError(err)
+
+			loader := openapi3.NewLoader()
+
+			inputSpec, err := loader.LoadFromData(sourceBytes)
+			s.Require().NoError(err)
+
+			expectedBytes, err := os.ReadFile(path[:len(path)-len(suffix)] + "_out.yaml")
+			s.Require().NoError(err)
+			err = yaml.Unmarshal(expectedBytes, &expectedYAML)
+			s.Require().NoError(err)
+
+			output, err := DowngradeTo3_0(inputSpec)
+			s.Require().NoError(err)
+
+			convertedYAML = specToMap(output)
+
+			// We use gomega here as it gives better error indications
+			if diff := cmp.Diff(convertedYAML, expectedYAML); diff != "" {
+				s.Failf("MakeGatewayInfo() mismatch (-want +got):\n%s", diff)
+			}
+			// g.Expect(actual).Should(gomega.MatchYAML(expected))
+			// s.EqualValues(expectedSpec, output)
+		})
+	}
+}

--- a/pkg/openapi31downgrade/testdata/airflow_example_in.yaml
+++ b/pkg/openapi31downgrade/testdata/airflow_example_in.yaml
@@ -1,0 +1,1233 @@
+openapi: 3.1.0
+info:
+  title: Airflow Task Execution API
+  description: The private Airflow Task Execution API.
+  version: "2025-04-11"
+servers:
+  - url: /execution
+paths:
+  /assets/by-name:
+    get:
+      tags:
+        - Assets
+      summary: Get Asset By Name
+      description: Get an Airflow Asset by `name`.
+      operationId: get_asset_by_name
+      parameters:
+        - name: name
+          in: query
+          required: true
+          schema:
+            type: string
+            description: The name of the Asset
+            title: Name
+          description: The name of the Asset
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetResponse'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /asset-events/by-asset:
+    get:
+      tags:
+        - Asset Events
+      summary: Get Asset Event By Asset Name Uri
+      operationId: get_asset_event_by_asset_name_uri
+      parameters:
+        - name: name
+          in: query
+          required: true
+          schema:
+            oneOf:
+              - type: string
+              - type: "null"
+            description: The name of the Asset
+            title: Name
+          description: The name of the Asset
+        - name: uri
+          in: query
+          required: true
+          schema:
+            oneOf:
+              - type: string
+              - type: "null"
+            description: The URI of the Asset
+            title: Uri
+          description: The URI of the Asset
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetEventsResponse'
+  /task-instances/count:
+    get:
+      tags:
+        - Task Instances
+      summary: Get Task Instance Count
+      description: Get the count of task instances matching the given criteria.
+      operationId: get_task_instance_count
+      parameters:
+        - name: dag_id
+          in: query
+          required: true
+          schema:
+            type: string
+            title: Dag Id
+        - name: task_ids
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: array
+                items:
+                  type: string
+              - type: "null"
+            title: Task Ids
+        - name: task_group_id
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: string
+              - type: "null"
+            title: Task Group Id
+        - name: logical_dates
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: array
+                items:
+                  type: string
+                  format: date-time
+              - type: "null"
+            title: Logical Dates
+        - name: run_ids
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: array
+                items:
+                  type: string
+              - type: "null"
+            title: Run Ids
+        - name: states
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: array
+                items:
+                  type: string
+              - type: "null"
+            title: States
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: integer
+                title: Response Get Task Instance Count
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /task-instances/states:
+    get:
+      tags:
+        - Task Instances
+      summary: Get Task Instance States
+      description: Get the states for Task Instances with the given criteria.
+      operationId: get_task_instance_states
+      parameters:
+        - name: dag_id
+          in: query
+          required: true
+          schema:
+            type: string
+            title: Dag Id
+        - name: task_ids
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: array
+                items:
+                  type: string
+              - type: "null"
+            title: Task Ids
+        - name: task_group_id
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: string
+              - type: "null"
+            title: Task Group Id
+        - name: logical_dates
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: array
+                items:
+                  type: string
+                  format: date-time
+              - type: "null"
+            title: Logical Dates
+        - name: run_ids
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: array
+                items:
+                  type: string
+              - type: "null"
+            title: Run Ids
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskStatesResponse'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /task-instances/{task_instance_id}/run:
+    patch:
+      tags:
+        - Task Instances
+      summary: Ti Run
+      description: |-
+        Run a TaskInstance.
+
+        This endpoint is used to start a TaskInstance that is in the QUEUED state.
+      operationId: ti_run
+      parameters:
+        - name: task_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Task Instance Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TIEnterRunningPayload'
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TIRunContext'
+        "404":
+          description: Task Instance not found
+        "409":
+          description: The TI is already in the requested state
+        "422":
+          description: Invalid payload for the state transition
+  /task-instances/{task_instance_id}/state:
+    patch:
+      tags:
+        - Task Instances
+      summary: Ti Update State
+      description: |-
+        Update the state of a TaskInstance.
+
+        Not all state transitions are valid, and transitioning to some states requires extra information to be
+        passed along. (Check out the datamodels for details, the rendered docs might not reflect this accurately)
+      operationId: ti_update_state
+      parameters:
+        - name: task_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Task Instance Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/TITerminalStatePayload'
+                - $ref: '#/components/schemas/TISuccessStatePayload'
+                - $ref: '#/components/schemas/TITargetStatePayload'
+                - $ref: '#/components/schemas/TIDeferredStatePayload'
+                - $ref: '#/components/schemas/TIRescheduleStatePayload'
+                - $ref: '#/components/schemas/TIRetryStatePayload'
+              title: Ti Patch Payload
+      responses:
+        "204":
+          description: Successful Response
+        "404":
+          description: Task Instance not found
+        "409":
+          description: The TI is already in the requested state
+        "422":
+          description: Invalid payload for the state transition
+  /task-instances/{task_instance_id}/heartbeat:
+    put:
+      tags:
+        - Task Instances
+      summary: Ti Heartbeat
+      description: Update the heartbeat of a TaskInstance to mark it as alive & still running.
+      operationId: ti_heartbeat
+      parameters:
+        - name: task_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Task Instance Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TIHeartbeatInfo'
+      responses:
+        "204":
+          description: Successful Response
+        "404":
+          description: Task Instance not found
+        "409":
+          description: The TI attempting to heartbeat should be terminated for the given reason
+        "422":
+          description: Invalid payload for the state transition
+  /task-instances/{task_instance_id}/rtif:
+    put:
+      tags:
+        - Task Instances
+      summary: Ti Put Rtif
+      description: Add an RTIF entry for a task instance, sent by the worker.
+      operationId: ti_put_rtif
+      parameters:
+        - name: task_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Task Instance Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                $ref: '#/components/schemas/JsonValue'
+              title: Put Rtif Payload
+      responses:
+        "201":
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        "404":
+          description: Task Instance not found
+        "422":
+          description: Invalid payload for the setting rendered task instance fields
+  /task-instances/{task_instance_id}/previous-successful-dagrun:
+    get:
+      tags:
+        - Task Instances
+      summary: Get Previous Successful Dagrun
+      description: |-
+        Get the previous successful DagRun for a TaskInstance.
+
+        The data from this endpoint is used to get values for Task Context.
+      operationId: get_previous_successful_dagrun
+      parameters:
+        - name: task_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Task Instance Id
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrevSuccessfulDagRunResponse'
+        "404":
+          description: Task Instance or Dag Run not found
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /task-reschedules/{task_instance_id}/start_date:
+    get:
+      tags:
+        - Task Reschedules
+      summary: Get Start Date
+      description: Get the first reschedule date if found, None if no records exist.
+      operationId: get_start_date
+      parameters:
+        - name: task_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+            title: Task Instance Id
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - type: string
+                    format: date-time
+                  - type: "null"
+                title: Response Get Start Date
+        "404":
+          description: Task Instance not found
+        "401":
+          description: Unauthorized
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /variables/{variable_key}:
+  /xcoms/{dag_id}/{run_id}/{task_id}/{key}:
+    head:
+      tags:
+        - XComs
+      summary: Head Xcom
+      description: Returns the count of mapped XCom values found in the `Content-Range` response header
+      operationId: head_xcom
+      parameters:
+        - name: dag_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Dag Id
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Run Id
+        - name: task_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Task Id
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Key
+        - name: map_index
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: integer
+              - type: "null"
+            title: Map Index
+      responses:
+        "200":
+          description: Metadata about the number of matching XCom values
+          content:
+            application/json:
+              schema:
+                type: "null"
+                title: Response Head Xcom
+          headers:
+            Content-Range:
+              schema:
+                pattern: ^map_indexes \d+$
+              description: The number of (mapped) XCom values found for this task.
+        "401":
+          description: Unauthorized
+        "403":
+          description: Task does not have access to the XCom
+        "404":
+          description: XCom not found
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+        - XComs
+      summary: Set Xcom
+      description: Set an Airflow XCom.
+      operationId: set_xcom
+      parameters:
+        - name: dag_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Dag Id
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Run Id
+        - name: task_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Task Id
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Key
+        - name: map_index
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: -1
+            title: Map Index
+        - name: mapped_length
+          in: query
+          required: false
+          schema:
+            oneOf:
+              - type: integer
+              - type: "null"
+            description: Number of mapped tasks this value expands into
+            title: Mapped Length
+          description: Number of mapped tasks this value expands into
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JsonValue'
+              description: A JSON-formatted string representing the value to set for the XCom.
+            examples:
+              simple_value:
+                summary: Simple value
+                value: '"value1"'
+              dict_value:
+                summary: Dictionary value
+                value: '{"key2": "value2"}'
+              list_value:
+                summary: List value
+                value: '["value1"]'
+      responses:
+        "201":
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        "401":
+          description: Unauthorized
+        "403":
+          description: Task does not have access to the XCom
+        "404":
+          description: XCom not found
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+        - XComs
+      summary: Delete Xcom
+      description: Delete a single XCom Value
+      operationId: delete_xcom
+      parameters:
+        - name: dag_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Dag Id
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Run Id
+        - name: task_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Task Id
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Key
+        - name: map_index
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: -1
+            title: Map Index
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        "401":
+          description: Unauthorized
+        "403":
+          description: Task does not have access to the XCom
+        "404":
+          description: XCom not found
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    AssetAliasReferenceAssetEventDagRun:
+      properties:
+        name:
+          type: string
+          title: Name
+      additionalProperties: false
+      type: object
+      required:
+        - name
+      title: AssetAliasReferenceAssetEventDagRun
+      description: Schema for AssetAliasModel used in AssetEventDagRunReference.
+    AssetEventDagRunReference:
+      properties:
+        asset:
+          $ref: '#/components/schemas/AssetReferenceAssetEventDagRun'
+        extra:
+          additionalProperties: true
+          type: object
+          title: Extra
+        source_task_id:
+          oneOf:
+            - type: string
+            - type: "null"
+          title: Source Task Id
+        source_dag_id:
+          oneOf:
+            - type: string
+            - type: "null"
+          title: Source Dag Id
+        source_run_id:
+          oneOf:
+            - type: string
+            - type: "null"
+          title: Source Run Id
+        source_map_index:
+          oneOf:
+            - type: integer
+            - type: "null"
+          title: Source Map Index
+        source_aliases:
+          items:
+            $ref: '#/components/schemas/AssetAliasReferenceAssetEventDagRun'
+          type: array
+          title: Source Aliases
+        timestamp:
+          type: string
+          format: date-time
+          title: Timestamp
+      additionalProperties: false
+      type: object
+      required:
+        - asset
+        - extra
+        - source_task_id
+        - source_dag_id
+        - source_run_id
+        - source_map_index
+        - source_aliases
+        - timestamp
+      title: AssetEventDagRunReference
+      description: Schema for AssetEvent model used in DagRun.
+    AssetEventResponse:
+      properties:
+        id:
+          type: integer
+          title: Id
+        timestamp:
+          type: string
+          format: date-time
+          title: Timestamp
+        extra:
+          oneOf:
+            - additionalProperties: true
+              type: object
+            - type: "null"
+          title: Extra
+        asset:
+          $ref: '#/components/schemas/AssetResponse'
+        source_task_id:
+          oneOf:
+            - type: string
+            - type: "null"
+          title: Source Task Id
+        source_dag_id:
+          oneOf:
+            - type: string
+            - type: "null"
+          title: Source Dag Id
+        source_run_id:
+          oneOf:
+            - type: string
+            - type: "null"
+          title: Source Run Id
+        source_map_index:
+          type: integer
+          title: Source Map Index
+          default: -1
+      type: object
+      required:
+        - id
+        - timestamp
+        - asset
+      title: AssetEventResponse
+      description: Asset event schema with fields that are needed for Runtime.
+    AssetEventsResponse:
+      properties:
+        asset_events:
+          items:
+            $ref: '#/components/schemas/AssetEventResponse'
+          type: array
+          title: Asset Events
+      type: object
+      required:
+        - asset_events
+      title: AssetEventsResponse
+      description: Collection of AssetEventResponse.
+    AssetProfile:
+      properties:
+        name:
+          oneOf:
+            - type: string
+            - type: "null"
+          title: Name
+        uri:
+          oneOf:
+            - type: string
+            - type: "null"
+          title: Uri
+        type:
+          type: string
+          title: Type
+      additionalProperties: false
+      type: object
+      required:
+        - type
+      title: AssetProfile
+      description: |-
+        Profile of an asset-like object.
+
+        Asset will have name, uri defined, with type set to 'Asset'.
+        AssetNameRef will have name defined, type set to 'AssetNameRef'.
+        AssetUriRef will have uri defined, type set to 'AssetUriRef'.
+        AssetAlias will have name defined, type set to 'AssetAlias'.
+
+        Note that 'type' here is distinct from 'asset_type' the user declares on an
+        Asset (or subclass). This field is for distinguishing between different
+        asset-related types (Asset, AssetRef, or AssetAlias).
+    AssetReferenceAssetEventDagRun:
+      properties:
+        name:
+          type: string
+          title: Name
+        uri:
+          type: string
+          title: Uri
+        extra:
+          additionalProperties: true
+          type: object
+          title: Extra
+      additionalProperties: false
+      type: object
+      required:
+        - name
+        - uri
+        - extra
+      title: AssetReferenceAssetEventDagRun
+      description: Schema for AssetModel used in AssetEventDagRunReference.
+    AssetResponse:
+      properties:
+        name:
+          type: string
+          title: Name
+        uri:
+          type: string
+          title: Uri
+        group:
+          type: string
+          title: Group
+        extra:
+          oneOf:
+            - additionalProperties: true
+              type: object
+            - type: "null"
+          title: Extra
+      type: object
+      required:
+        - name
+        - uri
+        - group
+      title: AssetResponse
+      description: Asset schema for responses with fields that are needed for Runtime.
+    DagRunState:
+      type: string
+      enum:
+        - queued
+        - running
+        - success
+        - failed
+      title: DagRunState
+      description: |-
+        All possible states that a DagRun can be in.
+
+        These are "shared" with TaskInstanceState in some parts of the code,
+        so please ensure that their values always match the ones with the
+        same name in TaskInstanceState.
+    DagRunStateResponse:
+      properties:
+        state:
+          $ref: '#/components/schemas/DagRunState'
+      type: object
+      required:
+        - state
+      title: DagRunStateResponse
+      description: Schema for DAG Run State response.
+    DagRunType:
+      type: string
+      enum:
+        - backfill
+        - scheduled
+        - manual
+        - asset_triggered
+      title: DagRunType
+      description: Class with DagRun types.
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          type: array
+          title: Detail
+      type: object
+      title: HTTPValidationError
+    IntermediateTIState:
+      type: string
+      enum:
+        - scheduled
+        - queued
+        - restarting
+        - up_for_retry
+        - up_for_reschedule
+        - upstream_failed
+        - deferred
+      title: IntermediateTIState
+      description: States that a Task Instance can be in that indicate it is not yet in a terminal or running state.
+    JsonValue:
+      title: Any valid JSON value
+      oneOf:
+        - type: string
+        - type: number
+        - type: integer
+        - type: object
+        - type: array
+        - type: boolean
+        - type: "null"
+    PrevSuccessfulDagRunResponse:
+      properties:
+        data_interval_start:
+          oneOf:
+            - type: string
+              format: date-time
+            - type: "null"
+          title: Data Interval Start
+        data_interval_end:
+          oneOf:
+            - type: string
+              format: date-time
+            - type: "null"
+          title: Data Interval End
+        start_date:
+          oneOf:
+            - type: string
+              format: date-time
+            - type: "null"
+          title: Start Date
+        end_date:
+          oneOf:
+            - type: string
+              format: date-time
+            - type: "null"
+          title: End Date
+      type: object
+      title: PrevSuccessfulDagRunResponse
+      description: Schema for response with previous successful DagRun information for Task Template Context.
+    TIDeferredStatePayload:
+      properties:
+        state:
+          type: string
+          enum:
+            - deferred
+          title: State
+          default: deferred
+        classpath:
+          type: string
+          title: Classpath
+        trigger_kwargs:
+          oneOf:
+            - additionalProperties: true
+              type: object
+            - type: string
+          title: Trigger Kwargs
+        trigger_timeout:
+          oneOf:
+            - type: string
+              format: duration
+            - type: "null"
+          title: Trigger Timeout
+        next_method:
+          type: string
+          title: Next Method
+        next_kwargs:
+          oneOf:
+            - additionalProperties: true
+              type: object
+            - type: string
+          title: Next Kwargs
+      additionalProperties: false
+      type: object
+      required:
+        - state
+        - classpath
+        - next_method
+      title: TIDeferredStatePayload
+      description: Schema for updating TaskInstance to a deferred state.
+    TIEnterRunningPayload:
+      properties:
+        state:
+          type: string
+          enum:
+            - running
+          title: State
+          default: running
+        hostname:
+          type: string
+          title: Hostname
+        unixname:
+          type: string
+          title: Unixname
+        pid:
+          type: integer
+          title: Pid
+        start_date:
+          type: string
+          format: date-time
+          title: Start Date
+      additionalProperties: false
+      type: object
+      required:
+        - state
+        - hostname
+        - unixname
+        - pid
+        - start_date
+      title: TIEnterRunningPayload
+      description: Schema for updating TaskInstance to 'RUNNING' state with minimal required fields.
+    TIHeartbeatInfo:
+      properties:
+        hostname:
+          type: string
+          title: Hostname
+        pid:
+          type: integer
+          title: Pid
+      additionalProperties: false
+      type: object
+      required:
+        - hostname
+        - pid
+      title: TIHeartbeatInfo
+      description: Schema for TaskInstance heartbeat endpoint.
+    TIRescheduleStatePayload:
+      properties:
+        state:
+          type: string
+          enum:
+            - up_for_reschedule
+          title: State
+          default: up_for_reschedule
+        reschedule_date:
+          type: string
+          format: date-time
+          title: Reschedule Date
+        end_date:
+          type: string
+          format: date-time
+          title: End Date
+      additionalProperties: false
+      type: object
+      required:
+        - state
+        - reschedule_date
+        - end_date
+      title: TIRescheduleStatePayload
+      description: Schema for updating TaskInstance to a up_for_reschedule state.
+    TIRetryStatePayload:
+      properties:
+        state:
+          type: string
+          enum:
+            - up_for_retry
+          title: State
+          default: up_for_retry
+        end_date:
+          type: string
+          format: date-time
+          title: End Date
+      additionalProperties: false
+      type: object
+      required:
+        - state
+        - end_date
+      title: TIRetryStatePayload
+      description: Schema for updating TaskInstance to up_for_retry.
+    TIRunContext:
+      properties:
+        task_reschedule_count:
+          type: integer
+          title: Task Reschedule Count
+          default: 0
+        max_tries:
+          type: integer
+          title: Max Tries
+        upstream_map_indexes:
+          oneOf:
+            - additionalProperties:
+                type: integer
+              type: object
+            - type: "null"
+          title: Upstream Map Indexes
+        next_method:
+          oneOf:
+            - type: string
+            - type: "null"
+          title: Next Method
+        next_kwargs:
+          oneOf:
+            - additionalProperties: true
+              type: object
+            - type: string
+            - type: "null"
+          title: Next Kwargs
+        xcom_keys_to_clear:
+          items:
+            type: string
+          type: array
+          title: Xcom Keys To Clear
+        should_retry:
+          type: boolean
+          title: Should Retry
+      type: object
+      required:
+        - dag_run
+        - max_tries
+        - should_retry
+      title: TIRunContext
+      description: Response schema for TaskInstance run context.
+    TISuccessStatePayload:
+      properties:
+        state:
+          type: string
+          enum:
+            - success
+          title: State
+          default: success
+        end_date:
+          type: string
+          format: date-time
+          title: End Date
+        task_outlets:
+          items:
+            $ref: '#/components/schemas/AssetProfile'
+          type: array
+          title: Task Outlets
+        outlet_events:
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+          title: Outlet Events
+      additionalProperties: false
+      type: object
+      required:
+        - state
+        - end_date
+      title: TISuccessStatePayload
+      description: Schema for updating TaskInstance to success state.
+    TITargetStatePayload:
+      properties:
+        state:
+          $ref: '#/components/schemas/IntermediateTIState'
+      additionalProperties: false
+      type: object
+      required:
+        - state
+      title: TITargetStatePayload
+      description: Schema for updating TaskInstance to a target state, excluding terminal and running states.
+    TITerminalStatePayload:
+      properties:
+        state:
+          $ref: '#/components/schemas/TerminalStateNonSuccess'
+        end_date:
+          type: string
+          format: date-time
+          title: End Date
+      additionalProperties: false
+      type: object
+      required:
+        - state
+        - end_date
+      title: TITerminalStatePayload
+      description: Schema for updating TaskInstance to a terminal state except SUCCESS state.
+    TaskStatesResponse:
+      properties:
+        task_states:
+          additionalProperties: true
+          type: object
+          title: Task States
+      type: object
+      required:
+        - task_states
+      title: TaskStatesResponse
+      description: Response for task states with run_id, task and state.
+    TerminalStateNonSuccess:
+      type: string
+      enum:
+        - failed
+        - skipped
+        - removed
+      title: TerminalStateNonSuccess
+      description: TaskInstance states that can be reported without extra information.
+    ValidationError:
+      properties:
+        loc:
+          items:
+            oneOf:
+              - type: string
+              - type: integer
+          type: array
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      type: object
+      required:
+        - loc
+        - msg
+        - type
+      title: ValidationError
+    TaskInstance:
+      description: Schema for TaskInstance model with minimal required fields needed for Runtime.
+      properties:
+        id:
+          format: uuid
+          title: Id
+          type: string
+        task_id:
+          title: Task Id
+          type: string
+        dag_id:
+          title: Dag Id
+          type: string
+        run_id:
+          title: Run Id
+          type: string
+        try_number:
+          title: Try Number
+          type: integer
+        map_index:
+          default: -1
+          title: Map Index
+          type: integer
+        hostname:
+          oneOf:
+            - type: string
+            - type: "null"
+          default: null
+          title: Hostname
+        context_carrier:
+          oneOf:
+            - additionalProperties: true
+              type: object
+            - type: "null"
+          default: null
+          title: Context Carrier
+      required:
+        - id
+        - task_id
+        - dag_id
+        - run_id
+        - try_number
+      title: TaskInstance
+      type: object
+    TerminalTIState:
+      type: string
+      enum:
+        - success
+        - failed
+        - skipped
+        - removed

--- a/pkg/openapi31downgrade/testdata/airflow_example_out.yaml
+++ b/pkg/openapi31downgrade/testdata/airflow_example_out.yaml
@@ -1,0 +1,1184 @@
+openapi: 3.0.0
+info:
+  title: Airflow Task Execution API
+  description: The private Airflow Task Execution API.
+  version: "2025-04-11"
+servers:
+  - url: /execution
+paths:
+  /asset-events/by-asset:
+    get:
+      tags:
+        - Asset Events
+      summary: Get Asset Event By Asset Name Uri
+      operationId: get_asset_event_by_asset_name_uri
+      parameters:
+        - name: name
+          in: query
+          description: The name of the Asset
+          required: true
+          schema:
+            title: Name
+            description: The name of the Asset
+            type: string
+            nullable: true
+        - name: uri
+          in: query
+          description: The URI of the Asset
+          required: true
+          schema:
+            title: Uri
+            description: The URI of the Asset
+            type: string
+            nullable: true
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetEventsResponse'
+  /assets/by-name:
+    get:
+      tags:
+        - Assets
+      summary: Get Asset By Name
+      description: Get an Airflow Asset by `name`.
+      operationId: get_asset_by_name
+      parameters:
+        - name: name
+          in: query
+          description: The name of the Asset
+          required: true
+          schema:
+            type: string
+            title: Name
+            description: The name of the Asset
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetResponse'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /task-instances/count:
+    get:
+      tags:
+        - Task Instances
+      summary: Get Task Instance Count
+      description: Get the count of task instances matching the given criteria.
+      operationId: get_task_instance_count
+      parameters:
+        - name: dag_id
+          in: query
+          required: true
+          schema:
+            type: string
+            title: Dag Id
+        - name: task_ids
+          in: query
+          schema:
+            title: Task Ids
+            type: array
+            items:
+              type: string
+            nullable: true
+        - name: task_group_id
+          in: query
+          schema:
+            title: Task Group Id
+            type: string
+            nullable: true
+        - name: logical_dates
+          in: query
+          schema:
+            title: Logical Dates
+            type: array
+            items:
+              type: string
+              format: date-time
+            nullable: true
+        - name: run_ids
+          in: query
+          schema:
+            title: Run Ids
+            type: array
+            items:
+              type: string
+            nullable: true
+        - name: states
+          in: query
+          schema:
+            title: States
+            type: array
+            items:
+              type: string
+            nullable: true
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: integer
+                title: Response Get Task Instance Count
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /task-instances/states:
+    get:
+      tags:
+        - Task Instances
+      summary: Get Task Instance States
+      description: Get the states for Task Instances with the given criteria.
+      operationId: get_task_instance_states
+      parameters:
+        - name: dag_id
+          in: query
+          required: true
+          schema:
+            type: string
+            title: Dag Id
+        - name: task_ids
+          in: query
+          schema:
+            title: Task Ids
+            type: array
+            items:
+              type: string
+            nullable: true
+        - name: task_group_id
+          in: query
+          schema:
+            title: Task Group Id
+            type: string
+            nullable: true
+        - name: logical_dates
+          in: query
+          schema:
+            title: Logical Dates
+            type: array
+            items:
+              type: string
+              format: date-time
+            nullable: true
+        - name: run_ids
+          in: query
+          schema:
+            title: Run Ids
+            type: array
+            items:
+              type: string
+            nullable: true
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskStatesResponse'
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /task-instances/{task_instance_id}/heartbeat:
+    put:
+      tags:
+        - Task Instances
+      summary: Ti Heartbeat
+      description: Update the heartbeat of a TaskInstance to mark it as alive & still running.
+      operationId: ti_heartbeat
+      parameters:
+        - name: task_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Task Instance Id
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TIHeartbeatInfo'
+        required: true
+      responses:
+        "204":
+          description: Successful Response
+        "404":
+          description: Task Instance not found
+        "409":
+          description: The TI attempting to heartbeat should be terminated for the given reason
+        "422":
+          description: Invalid payload for the state transition
+  /task-instances/{task_instance_id}/previous-successful-dagrun:
+    get:
+      tags:
+        - Task Instances
+      summary: Get Previous Successful Dagrun
+      description: |-
+        Get the previous successful DagRun for a TaskInstance.
+
+        The data from this endpoint is used to get values for Task Context.
+      operationId: get_previous_successful_dagrun
+      parameters:
+        - name: task_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Task Instance Id
+            format: uuid
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrevSuccessfulDagRunResponse'
+        "404":
+          description: Task Instance or Dag Run not found
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /task-instances/{task_instance_id}/rtif:
+    put:
+      tags:
+        - Task Instances
+      summary: Ti Put Rtif
+      description: Add an RTIF entry for a task instance, sent by the worker.
+      operationId: ti_put_rtif
+      parameters:
+        - name: task_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Task Instance Id
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              title: Put Rtif Payload
+              additionalProperties:
+                $ref: '#/components/schemas/JsonValue'
+        required: true
+      responses:
+        "201":
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        "404":
+          description: Task Instance not found
+        "422":
+          description: Invalid payload for the setting rendered task instance fields
+  /task-instances/{task_instance_id}/run:
+    patch:
+      tags:
+        - Task Instances
+      summary: Ti Run
+      description: |-
+        Run a TaskInstance.
+
+        This endpoint is used to start a TaskInstance that is in the QUEUED state.
+      operationId: ti_run
+      parameters:
+        - name: task_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Task Instance Id
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TIEnterRunningPayload'
+        required: true
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TIRunContext'
+        "404":
+          description: Task Instance not found
+        "409":
+          description: The TI is already in the requested state
+        "422":
+          description: Invalid payload for the state transition
+  /task-instances/{task_instance_id}/state:
+    patch:
+      tags:
+        - Task Instances
+      summary: Ti Update State
+      description: |-
+        Update the state of a TaskInstance.
+
+        Not all state transitions are valid, and transitioning to some states requires extra information to be
+        passed along. (Check out the datamodels for details, the rendered docs might not reflect this accurately)
+      operationId: ti_update_state
+      parameters:
+        - name: task_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Task Instance Id
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/TITerminalStatePayload'
+                - $ref: '#/components/schemas/TISuccessStatePayload'
+                - $ref: '#/components/schemas/TITargetStatePayload'
+                - $ref: '#/components/schemas/TIDeferredStatePayload'
+                - $ref: '#/components/schemas/TIRescheduleStatePayload'
+                - $ref: '#/components/schemas/TIRetryStatePayload'
+              title: Ti Patch Payload
+        required: true
+      responses:
+        "204":
+          description: Successful Response
+        "404":
+          description: Task Instance not found
+        "409":
+          description: The TI is already in the requested state
+        "422":
+          description: Invalid payload for the state transition
+  /task-reschedules/{task_instance_id}/start_date:
+    get:
+      tags:
+        - Task Reschedules
+      summary: Get Start Date
+      description: Get the first reschedule date if found, None if no records exist.
+      operationId: get_start_date
+      parameters:
+        - name: task_instance_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Task Instance Id
+            format: uuid
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                title: Response Get Start Date
+                type: string
+                format: date-time
+                nullable: true
+        "401":
+          description: Unauthorized
+        "404":
+          description: Task Instance not found
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /variables/{variable_key}: {}
+  /xcoms/{dag_id}/{run_id}/{task_id}/{key}:
+    post:
+      tags:
+        - XComs
+      summary: Set Xcom
+      description: Set an Airflow XCom.
+      operationId: set_xcom
+      parameters:
+        - name: dag_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Dag Id
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Run Id
+        - name: task_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Task Id
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Key
+        - name: map_index
+          in: query
+          schema:
+            type: integer
+            title: Map Index
+            default: -1
+        - name: mapped_length
+          in: query
+          description: Number of mapped tasks this value expands into
+          schema:
+            title: Mapped Length
+            description: Number of mapped tasks this value expands into
+            type: integer
+            nullable: true
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JsonValue'
+            examples:
+              dict_value:
+                summary: Dictionary value
+                value: '{"key2": "value2"}'
+              list_value:
+                summary: List value
+                value: '["value1"]'
+              simple_value:
+                summary: Simple value
+                value: '"value1"'
+        required: true
+      responses:
+        "201":
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        "401":
+          description: Unauthorized
+        "403":
+          description: Task does not have access to the XCom
+        "404":
+          description: XCom not found
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+        - XComs
+      summary: Delete Xcom
+      description: Delete a single XCom Value
+      operationId: delete_xcom
+      parameters:
+        - name: dag_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Dag Id
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Run Id
+        - name: task_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Task Id
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Key
+        - name: map_index
+          in: query
+          schema:
+            type: integer
+            title: Map Index
+            default: -1
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        "401":
+          description: Unauthorized
+        "403":
+          description: Task does not have access to the XCom
+        "404":
+          description: XCom not found
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    head:
+      tags:
+        - XComs
+      summary: Head Xcom
+      description: Returns the count of mapped XCom values found in the `Content-Range` response header
+      operationId: head_xcom
+      parameters:
+        - name: dag_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Dag Id
+        - name: run_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Run Id
+        - name: task_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Task Id
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Key
+        - name: map_index
+          in: query
+          schema:
+            title: Map Index
+            type: integer
+            nullable: true
+      responses:
+        "200":
+          description: Metadata about the number of matching XCom values
+          headers:
+            Content-Range:
+              description: The number of (mapped) XCom values found for this task.
+              schema:
+                pattern: ^map_indexes \d+$
+          content:
+            application/json:
+              schema:
+                title: Response Head Xcom
+                nullable: true
+        "401":
+          description: Unauthorized
+        "403":
+          description: Task does not have access to the XCom
+        "404":
+          description: XCom not found
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    AssetAliasReferenceAssetEventDagRun:
+      type: object
+      properties:
+        name:
+          type: string
+          title: Name
+      title: AssetAliasReferenceAssetEventDagRun
+      required:
+        - name
+      additionalProperties: false
+      description: Schema for AssetAliasModel used in AssetEventDagRunReference.
+    AssetEventDagRunReference:
+      type: object
+      properties:
+        asset:
+          $ref: '#/components/schemas/AssetReferenceAssetEventDagRun'
+        extra:
+          type: object
+          title: Extra
+          additionalProperties: true
+        source_aliases:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssetAliasReferenceAssetEventDagRun'
+          title: Source Aliases
+        source_dag_id:
+          title: Source Dag Id
+          type: string
+          nullable: true
+        source_map_index:
+          title: Source Map Index
+          type: integer
+          nullable: true
+        source_run_id:
+          title: Source Run Id
+          type: string
+          nullable: true
+        source_task_id:
+          title: Source Task Id
+          type: string
+          nullable: true
+        timestamp:
+          type: string
+          title: Timestamp
+          format: date-time
+      title: AssetEventDagRunReference
+      required:
+        - asset
+        - extra
+        - source_task_id
+        - source_dag_id
+        - source_run_id
+        - source_map_index
+        - source_aliases
+        - timestamp
+      additionalProperties: false
+      description: Schema for AssetEvent model used in DagRun.
+    AssetEventResponse:
+      type: object
+      properties:
+        asset:
+          $ref: '#/components/schemas/AssetResponse'
+        extra:
+          title: Extra
+          type: object
+          additionalProperties: true
+          nullable: true
+        id:
+          type: integer
+          title: Id
+        source_dag_id:
+          title: Source Dag Id
+          type: string
+          nullable: true
+        source_map_index:
+          type: integer
+          title: Source Map Index
+          default: -1
+        source_run_id:
+          title: Source Run Id
+          type: string
+          nullable: true
+        source_task_id:
+          title: Source Task Id
+          type: string
+          nullable: true
+        timestamp:
+          type: string
+          title: Timestamp
+          format: date-time
+      title: AssetEventResponse
+      required:
+        - id
+        - timestamp
+        - asset
+      description: Asset event schema with fields that are needed for Runtime.
+    AssetEventsResponse:
+      type: object
+      properties:
+        asset_events:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssetEventResponse'
+          title: Asset Events
+      title: AssetEventsResponse
+      required:
+        - asset_events
+      description: Collection of AssetEventResponse.
+    AssetProfile:
+      type: object
+      properties:
+        name:
+          title: Name
+          type: string
+          nullable: true
+        type:
+          type: string
+          title: Type
+        uri:
+          title: Uri
+          type: string
+          nullable: true
+      title: AssetProfile
+      required:
+        - type
+      additionalProperties: false
+      description: |-
+        Profile of an asset-like object.
+
+        Asset will have name, uri defined, with type set to 'Asset'.
+        AssetNameRef will have name defined, type set to 'AssetNameRef'.
+        AssetUriRef will have uri defined, type set to 'AssetUriRef'.
+        AssetAlias will have name defined, type set to 'AssetAlias'.
+
+        Note that 'type' here is distinct from 'asset_type' the user declares on an
+        Asset (or subclass). This field is for distinguishing between different
+        asset-related types (Asset, AssetRef, or AssetAlias).
+    AssetReferenceAssetEventDagRun:
+      type: object
+      properties:
+        extra:
+          type: object
+          title: Extra
+          additionalProperties: true
+        name:
+          type: string
+          title: Name
+        uri:
+          type: string
+          title: Uri
+      title: AssetReferenceAssetEventDagRun
+      required:
+        - name
+        - uri
+        - extra
+      additionalProperties: false
+      description: Schema for AssetModel used in AssetEventDagRunReference.
+    AssetResponse:
+      type: object
+      properties:
+        extra:
+          title: Extra
+          type: object
+          additionalProperties: true
+          nullable: true
+        group:
+          type: string
+          title: Group
+        name:
+          type: string
+          title: Name
+        uri:
+          type: string
+          title: Uri
+      title: AssetResponse
+      required:
+        - name
+        - uri
+        - group
+      description: Asset schema for responses with fields that are needed for Runtime.
+    DagRunState:
+      type: string
+      title: DagRunState
+      enum:
+        - queued
+        - running
+        - success
+        - failed
+      description: |-
+        All possible states that a DagRun can be in.
+
+        These are "shared" with TaskInstanceState in some parts of the code,
+        so please ensure that their values always match the ones with the
+        same name in TaskInstanceState.
+    DagRunStateResponse:
+      type: object
+      properties:
+        state:
+          $ref: '#/components/schemas/DagRunState'
+      title: DagRunStateResponse
+      required:
+        - state
+      description: Schema for DAG Run State response.
+    DagRunType:
+      type: string
+      title: DagRunType
+      enum:
+        - backfill
+        - scheduled
+        - manual
+        - asset_triggered
+      description: Class with DagRun types.
+    HTTPValidationError:
+      type: object
+      properties:
+        detail:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          title: Detail
+      title: HTTPValidationError
+    IntermediateTIState:
+      type: string
+      title: IntermediateTIState
+      enum:
+        - scheduled
+        - queued
+        - restarting
+        - up_for_retry
+        - up_for_reschedule
+        - upstream_failed
+        - deferred
+      description: States that a Task Instance can be in that indicate it is not yet in a terminal or running state.
+    JsonValue:
+      oneOf:
+        - type: string
+        - type: number
+        - type: integer
+        - type: object
+        - type: array
+        - type: boolean
+      title: Any valid JSON value
+      nullable: true
+    PrevSuccessfulDagRunResponse:
+      type: object
+      properties:
+        data_interval_end:
+          title: Data Interval End
+          type: string
+          format: date-time
+          nullable: true
+        data_interval_start:
+          title: Data Interval Start
+          type: string
+          format: date-time
+          nullable: true
+        end_date:
+          title: End Date
+          type: string
+          format: date-time
+          nullable: true
+        start_date:
+          title: Start Date
+          type: string
+          format: date-time
+          nullable: true
+      title: PrevSuccessfulDagRunResponse
+      description: Schema for response with previous successful DagRun information for Task Template Context.
+    TIDeferredStatePayload:
+      type: object
+      properties:
+        classpath:
+          type: string
+          title: Classpath
+        next_kwargs:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: string
+          title: Next Kwargs
+        next_method:
+          type: string
+          title: Next Method
+        state:
+          type: string
+          title: State
+          enum:
+            - deferred
+          default: deferred
+        trigger_kwargs:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: string
+          title: Trigger Kwargs
+        trigger_timeout:
+          title: Trigger Timeout
+          type: string
+          format: duration
+          nullable: true
+      title: TIDeferredStatePayload
+      required:
+        - state
+        - classpath
+        - next_method
+      additionalProperties: false
+      description: Schema for updating TaskInstance to a deferred state.
+    TIEnterRunningPayload:
+      type: object
+      properties:
+        hostname:
+          type: string
+          title: Hostname
+        pid:
+          type: integer
+          title: Pid
+        start_date:
+          type: string
+          title: Start Date
+          format: date-time
+        state:
+          type: string
+          title: State
+          enum:
+            - running
+          default: running
+        unixname:
+          type: string
+          title: Unixname
+      title: TIEnterRunningPayload
+      required:
+        - state
+        - hostname
+        - unixname
+        - pid
+        - start_date
+      additionalProperties: false
+      description: Schema for updating TaskInstance to 'RUNNING' state with minimal required fields.
+    TIHeartbeatInfo:
+      type: object
+      properties:
+        hostname:
+          type: string
+          title: Hostname
+        pid:
+          type: integer
+          title: Pid
+      title: TIHeartbeatInfo
+      required:
+        - hostname
+        - pid
+      additionalProperties: false
+      description: Schema for TaskInstance heartbeat endpoint.
+    TIRescheduleStatePayload:
+      type: object
+      properties:
+        end_date:
+          type: string
+          title: End Date
+          format: date-time
+        reschedule_date:
+          type: string
+          title: Reschedule Date
+          format: date-time
+        state:
+          type: string
+          title: State
+          enum:
+            - up_for_reschedule
+          default: up_for_reschedule
+      title: TIRescheduleStatePayload
+      required:
+        - state
+        - reschedule_date
+        - end_date
+      additionalProperties: false
+      description: Schema for updating TaskInstance to a up_for_reschedule state.
+    TIRetryStatePayload:
+      type: object
+      properties:
+        end_date:
+          type: string
+          title: End Date
+          format: date-time
+        state:
+          type: string
+          title: State
+          enum:
+            - up_for_retry
+          default: up_for_retry
+      title: TIRetryStatePayload
+      required:
+        - state
+        - end_date
+      additionalProperties: false
+      description: Schema for updating TaskInstance to up_for_retry.
+    TIRunContext:
+      type: object
+      properties:
+        max_tries:
+          type: integer
+          title: Max Tries
+        next_kwargs:
+          oneOf:
+            - type: object
+              additionalProperties: true
+            - type: string
+          title: Next Kwargs
+          nullable: true
+        next_method:
+          title: Next Method
+          type: string
+          nullable: true
+        should_retry:
+          type: boolean
+          title: Should Retry
+        task_reschedule_count:
+          type: integer
+          title: Task Reschedule Count
+          default: 0
+        upstream_map_indexes:
+          title: Upstream Map Indexes
+          type: object
+          additionalProperties:
+            type: integer
+          nullable: true
+        xcom_keys_to_clear:
+          type: array
+          items:
+            type: string
+          title: Xcom Keys To Clear
+      title: TIRunContext
+      required:
+        - dag_run
+        - max_tries
+        - should_retry
+      description: Response schema for TaskInstance run context.
+    TISuccessStatePayload:
+      type: object
+      properties:
+        end_date:
+          type: string
+          title: End Date
+          format: date-time
+        outlet_events:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+          title: Outlet Events
+        state:
+          type: string
+          title: State
+          enum:
+            - success
+          default: success
+        task_outlets:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssetProfile'
+          title: Task Outlets
+      title: TISuccessStatePayload
+      required:
+        - state
+        - end_date
+      additionalProperties: false
+      description: Schema for updating TaskInstance to success state.
+    TITargetStatePayload:
+      type: object
+      properties:
+        state:
+          $ref: '#/components/schemas/IntermediateTIState'
+      title: TITargetStatePayload
+      required:
+        - state
+      additionalProperties: false
+      description: Schema for updating TaskInstance to a target state, excluding terminal and running states.
+    TITerminalStatePayload:
+      type: object
+      properties:
+        end_date:
+          type: string
+          title: End Date
+          format: date-time
+        state:
+          $ref: '#/components/schemas/TerminalStateNonSuccess'
+      title: TITerminalStatePayload
+      required:
+        - state
+        - end_date
+      additionalProperties: false
+      description: Schema for updating TaskInstance to a terminal state except SUCCESS state.
+    TaskInstance:
+      type: object
+      properties:
+        context_carrier:
+          title: Context Carrier
+          type: object
+          additionalProperties: true
+          nullable: true
+        dag_id:
+          type: string
+          title: Dag Id
+        hostname:
+          title: Hostname
+          type: string
+          nullable: true
+        id:
+          type: string
+          title: Id
+          format: uuid
+        map_index:
+          type: integer
+          title: Map Index
+          default: -1
+        run_id:
+          type: string
+          title: Run Id
+        task_id:
+          type: string
+          title: Task Id
+        try_number:
+          type: integer
+          title: Try Number
+      title: TaskInstance
+      required:
+        - id
+        - task_id
+        - dag_id
+        - run_id
+        - try_number
+      description: Schema for TaskInstance model with minimal required fields needed for Runtime.
+    TaskStatesResponse:
+      type: object
+      properties:
+        task_states:
+          type: object
+          title: Task States
+          additionalProperties: true
+      title: TaskStatesResponse
+      required:
+        - task_states
+      description: Response for task states with run_id, task and state.
+    TerminalStateNonSuccess:
+      type: string
+      title: TerminalStateNonSuccess
+      enum:
+        - failed
+        - skipped
+        - removed
+      description: TaskInstance states that can be reported without extra information.
+    TerminalTIState:
+      type: string
+      enum:
+        - success
+        - failed
+        - skipped
+        - removed
+    ValidationError:
+      type: object
+      properties:
+        loc:
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - type: integer
+          title: Location
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+      title: ValidationError
+      required:
+        - loc
+        - msg
+        - type
+

--- a/pkg/openapi31downgrade/testdata/airflow_example_out.yaml
+++ b/pkg/openapi31downgrade/testdata/airflow_example_out.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.0.3
 info:
   title: Airflow Task Execution API
   description: The private Airflow Task Execution API.


### PR DESCRIPTION
Since oapi-codegen is currently working out it's plan for 3.1 support (see
oapi-codegen/oapi-codegen issues 373) this converts enough for the Airflow
Execution API spec
