### PR TITLE
Correctly set bodies when they are not required

### DIFF
--- a/examples/petstore/client_test.go
+++ b/examples/petstore/client_test.go
@@ -41,9 +41,14 @@ func (suite *PetStoreSuite) TestInterfaces() {
 		Delete(ctx context.Context, petId int64, params *DeletePetParams) error
 		DeleteResponse(ctx context.Context, petId int64, params *DeletePetParams) (*resty.Response, error)
 	}
+	type DesiredUserClient interface {
+		Create(ctx context.Context, body *User) (*User, error)
+		CreateResponse(ctx context.Context, body *User) (*resty.Response, error)
+	}
 
 	type DesiredClientInterface interface {
 		Pet() PetClient
+		User() UserClient
 	}
 
 	_, ok := suite.client.(DesiredClientInterface)
@@ -52,6 +57,9 @@ func (suite *PetStoreSuite) TestInterfaces() {
 
 	_, ok = suite.client.Pet().(DesiredPetClient)
 	suite.True(ok, "PetClient implements DesiredPetClient")
+
+	_, ok = suite.client.User().(DesiredUserClient)
+	suite.True(ok, "UserClient implements DesiredUserClient")
 }
 
 func (suite *PetStoreSuite) TestAddOk() {
@@ -138,5 +146,16 @@ func (suite *PetStoreSuite) TestDelete() {
 		httpmock.NewBytesResponder(200, nil),
 	)
 	err := suite.client.Pet().Delete(context.Background(), 12, &params)
+	suite.Nil(err)
+}
+
+func (suite *PetStoreSuite) TestCreateUser() {
+	body := &User{}
+
+	suite.transport.RegisterResponder("POST", "/user",
+		httpmock.NewJsonResponderOrPanic(200, body),
+	)
+
+	_, err := suite.client.User().Create(context.Background(), body)
 	suite.Nil(err)
 }

--- a/examples/petstore/gen.config.yaml
+++ b/examples/petstore/gen.config.yaml
@@ -10,6 +10,6 @@ generate:
   client: true
 output-options:
   # To make test coverage better, we only include the endpoints we want to test!
-  include-operation-ids: [addPet, deletePet]
+  include-operation-ids: [addPet, deletePet, createUser]
   # overlay:
   #   path: overlay.yml

--- a/pkg/generator/templates/client-with-responses.tmpl
+++ b/pkg/generator/templates/client-with-responses.tmpl
@@ -1,7 +1,7 @@
 {{define "fnParams" }}ctx context.Context
     {{- .PathParams | genParamArgs -}}
     {{if .RequiresParamObject}}, params *{{.OperationId}}Params{{ end -}}
-    {{if .BodyRequired}}, body *{{ (.Bodies | bestBody).Schema.GoType }}{{ end -}}
+    {{if .HasBody}}, body *{{ (.Bodies | bestBody).Schema.GoType }}{{ end -}}
     {{- end -}}{{/*- end block params -*/}}
 
 
@@ -126,6 +126,7 @@ func (c *{{ $class }}) {{ $localOpid }}Response({{ template "fnParams" . }}) (re
     }
     {{ end -}}
     resp, err = c.R().
+      SetContext(ctx).
     {{- range $paramIdx, $param := .PathParams}}
       SetPathParam("{{ $param.ParamName }}", pathParam{{$paramIdx}}).{{end}}
     {{ range $paramIdx, $param := .Params -}}
@@ -135,7 +136,7 @@ func (c *{{ $class }}) {{ $localOpid }}Response({{ template "fnParams" . }}) (re
     SetQueryParam({{printf "%q" $param.ParamName}}, param{{$paramIdx}}).
     {{ end -}}
     {{- end -}}{{/* range .Params */}}
-    {{if .BodyRequired }}SetBody(body).{{ end}}
+    {{if .HasBody }}SetBody(body).{{ end}}
     {{- if $hasRespType }}
       SetResult(&res).
     {{- end }}
@@ -151,7 +152,7 @@ func (c *{{ $class }}) {{ $localOpid }}({{ template "fnParams" . -}}
   ) (*{{ $responseTypeName }}, error) {
     res, err := c.{{ $localOpid }}Response(ctx{{genParamNames .PathParams}}
       {{- if .RequiresParamObject}}, params{{ end -}}
-      {{- if .BodyRequired }}, body{{ end }})
+      {{- if .HasBody }}, body{{ end }})
     if err != nil {
       return nil, err
     }
@@ -159,7 +160,7 @@ func (c *{{ $class }}) {{ $localOpid }}({{ template "fnParams" . -}}
     return res.Result().(*{{ $responseTypeName }}), nil
 {{- else -}}
   ) error {
-    _, err := c.{{ $localOpid }}Response(ctx{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{ end -}})
+    _, err := c.{{ $localOpid }}Response(ctx{{genParamNames .PathParams}}{{if .RequiresParamObject}}, params{{ end -}}{{- if .HasBody }}, body{{ end }})
     return err
 {{- end }}
 }
@@ -185,7 +186,7 @@ type {{ $iface }} interface {
   {{ $localOpid }}({{block "params" $op }}ctx context.Context
     {{- .PathParams | genParamArgs -}}
     {{if .RequiresParamObject}}, params *{{.OperationId}}Params{{ end -}}
-    {{if .BodyRequired}}, body *{{ (.Bodies | bestBody).Schema.GoType }}{{ end -}}
+    {{if .HasBody}}, body *{{ (.Bodies | bestBody).Schema.GoType }}{{ end -}}
     {{- end -}}{{/*- end block params -*/}}
   {{- if $hasRespType -}}
   ) (*{{ $responseTypeName }}, error)


### PR DESCRIPTION
The OpenAPI spec differentiates between a body being required and a body being
possible. We only handled the former.
