### PR TITLE
Improve handling of required params object

### DIFF
--- a/examples/petstore/client_test.go
+++ b/examples/petstore/client_test.go
@@ -82,7 +82,7 @@ func (suite *PetStoreSuite) TestAddOk() {
 		Name:     "Midnight",
 		Status:   &status,
 	})
-	suite.Nil(err)
+	suite.NoError(err)
 	suite.NotNil(resp, "%s", resp)
 	suite.EqualValues(*resp.Id, 123)
 	suite.Equal(resp.Name, "Midnight")
@@ -148,7 +148,7 @@ func (suite *PetStoreSuite) TestDelete() {
 		httpmock.NewBytesResponder(200, nil),
 	)
 	err := suite.client.Pet().Delete(context.Background(), 12, &params)
-	suite.Nil(err)
+	suite.NoError(err)
 }
 
 func (suite *PetStoreSuite) TestFindByTags() {
@@ -191,9 +191,21 @@ func (suite *PetStoreSuite) TestFindByTags() {
 			)
 
 			_, err := suite.client.Pet().FindByTags(context.Background(), tc.params)
-			suite.Nil(err)
+			suite.NoError(err)
 		})
 	}
+}
+
+func (suite *PetStoreSuite) TestFindByStatus() {
+	suite.transport.RegisterResponder("GET", Prefix+"/pet/findByStatus",
+		httpmock.NewBytesResponder(200, nil),
+	)
+
+	_, err := suite.client.Pet().FindByStatus(context.Background(), nil)
+	suite.EqualError(err, "FindByStatus requires a non-nil params argument")
+
+	_, err = suite.client.Pet().FindByStatus(context.Background(), &FindPetsByStatusParams{})
+	suite.NoError(err)
 }
 
 func (suite *PetStoreSuite) TestCreateUser() {
@@ -204,5 +216,5 @@ func (suite *PetStoreSuite) TestCreateUser() {
 	)
 
 	_, err := suite.client.User().Create(context.Background(), body)
-	suite.Nil(err)
+	suite.NoError(err)
 }

--- a/examples/petstore/gen.config.yaml
+++ b/examples/petstore/gen.config.yaml
@@ -10,6 +10,6 @@ generate:
   client: true
 output-options:
   # To make test coverage better, we only include the endpoints we want to test!
-  include-operation-ids: [addPet, deletePet, createUser, findPetsByTags]
-  # overlay:
-  #   path: overlay.yml
+  include-operation-ids: [addPet, deletePet, createUser, findPetsByTags, findPetsByStatus]
+  overlay:
+    path: overlay.yaml

--- a/examples/petstore/overlay.yaml
+++ b/examples/petstore/overlay.yaml
@@ -1,0 +1,22 @@
+overlay: 1.0.0
+info:
+  title: OpenAPI Overlay
+  version: 0.0.0
+actions:
+- target: $.paths['/pet/findByStatus'].get
+  update:
+    parameters:
+      # Add two required query params
+      - name: animal
+        in: query
+        description: Month number of event (1-12)
+        required: true
+        schema:
+          type: string
+
+      - name: min_age
+        in: query
+        description: Start time of event
+        required: true
+        schema:
+          type: integer

--- a/pkg/generator/template_helpers.go
+++ b/pkg/generator/template_helpers.go
@@ -100,6 +100,15 @@ func paramLocationToSetter(p codegen.ParameterDefinition) string {
 	}
 }
 
+func hasRequiredParams(op codegen.OperationDefinition) bool {
+	for _, p := range op.Params() {
+		if p.Required {
+			return true
+		}
+	}
+	return false
+}
+
 func init() {
 	maps.Copy(codegen.TemplateFunctions, map[string]any{
 		"operationsByTag":         operationsByTag,
@@ -108,5 +117,6 @@ func init() {
 		"convertOperationWithTag": convertOperationWithTag,
 		"bestBody":                jsonTypeOrFirst[codegen.RequestBodyDefinition],
 		"paramLocationToSetter":   paramLocationToSetter,
+		"hasRequiredParams":       hasRequiredParams,
 	})
 }

--- a/pkg/generator/templates/client-with-responses.tmpl
+++ b/pkg/generator/templates/client-with-responses.tmpl
@@ -74,6 +74,12 @@ type {{ $class }} struct {
 
 // {{ $localOpid }}Response performs the HTTP request and returns the lower level [resty.Response]
 func (c *{{ $class }}) {{ $localOpid }}Response({{ template "fnParams" . }}) (resp *resty.Response, err error) {
+	{{ $hasRequiredParams := hasRequiredParams . }}
+	{{ if $hasRequiredParams -}}
+	if params == nil {
+		return nil, fmt.Errorf("{{ $localOpid }} requires a non-nil params argument")
+	}
+	{{- end }}
     {{ if $hasRespType -}}
     var res {{ $responseTypeName }}
     {{- end }}
@@ -112,7 +118,9 @@ func (c *{{ $class }}) {{ $localOpid }}Response({{ template "fnParams" . }}) (re
     {{end}}
     {{if .IsStyled}}
 		{{if .IndirectOptional }}
-		if params != nil && params.{{.GoName}} != nil {
+		if {{- if not $hasRequiredParams }} params != nil &&{{ end }} params.{{.GoName}} != nil {
+		{{else}}{{/* Create a scope block so `exploded` is only in scope for a short while */ -}}
+		{
 		{{end -}}
 
 		{{ if and .Explode (eq .In "query") }}
@@ -136,9 +144,7 @@ func (c *{{ $class }}) {{ $localOpid }}Response({{ template "fnParams" . }}) (re
 			req.{{ paramLocationToSetter $param }}({{$paramName}}, {{$paramVar}})
 		{{end -}}
     {{end -}}
-    {{if .IndirectOptional -}}
-		}
-    {{end -}}
+	}
 {{ end -}}{{/* range .Params */}}
 
     {{ if .BodyRequired -}}


### PR DESCRIPTION
Return a nice error (rather than a nil deref panic) and also use scoping
blocks so that multiple required params together still compile
